### PR TITLE
Fix GetUserInfoForCompetition userId in the request for a single problem

### DIFF
--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -46,7 +46,7 @@ func TestDefaultClient_GetUserInfoForCompetition(t *testing.T) {
 	req := &sdkreq.GetUserInfoForCompetitionReq{
 		CompetitionId: "",
 		SecretKey:     "",
-		UserId:        "",
+		UserIds:       []string{""},
 	}
 	res, err := client.GetUserInfoForCompetition(req)
 	if err != nil {


### PR DESCRIPTION
Fix GetUserInfoForCompetition userId in the request for a single problem